### PR TITLE
server: expose rpc dispatch latency to prometheus

### DIFF
--- a/src/core/histogram.cc
+++ b/src/core/histogram.cc
@@ -133,11 +133,10 @@ histogram::seastar_histogram_logform() const {
   // fill in buckets from hdr histogram logarithmic iteration. there may be more
   // or less hdr buckets reported than what will be returned to seastar.
   size_t bucket_idx = 0;
-  while (hdr_iter_next(&iter) && bucket_idx < sshist.buckets.size()) {
+  for (; hdr_iter_next(&iter) && bucket_idx < sshist.buckets.size(); bucket_idx++) {
     auto &bucket = sshist.buckets[bucket_idx];
     bucket.count = iter.cumulative_count;
     bucket.upper_bound = iter.value_iterated_to;
-    bucket_idx++;
   }
 
   if (bucket_idx == 0) {

--- a/src/core/histogram.cc
+++ b/src/core/histogram.cc
@@ -115,9 +115,9 @@ histogram::get_seastar_metrics_histogram() const {
   //   double but is truncated (see the int64_t casts on log_base below which is
   //   the same as in the hdr C library). this means that if we want buckets
   //   with a log base of 1.5, the histogram becomes linear...
-  const size_t num_buckets = 26;
-  const int64_t first_value = 10;
-  const double log_base = 2.0;
+  constexpr size_t num_buckets = 26;
+  constexpr int64_t first_value = 10;
+  constexpr double log_base = 2.0;
 
   seastar::metrics::histogram sshist;
   sshist.buckets.resize(num_buckets);

--- a/src/core/histogram.cc
+++ b/src/core/histogram.cc
@@ -123,7 +123,7 @@ histogram::get_seastar_metrics_histogram() const {
   sshist.buckets.resize(num_buckets);
 
   sshist.sample_count = hist_->sample_count;
-  sshist.sample_sum = (double)hist_->sample_sum;
+  sshist.sample_sum = static_cast<double>(hist_->sample_sum);
 
   // stack allocated; no cleanup needed
   struct hdr_iter iter;
@@ -148,7 +148,7 @@ histogram::get_seastar_metrics_histogram() const {
     // if there are padding buckets that need to be created, advance the bucket
     // boundary which would normally be done by hdr_iter_next, except that
     // doesn't happen when iteration reaches the end of the recorded values.
-    iter.value_iterated_to *= (int64_t)log->log_base;
+    iter.value_iterated_to *= static_cast<int64_t>(log->log_base);
   }
 
   // prometheus expects a fixed number of buckets. hdr iteration will stop after
@@ -157,7 +157,7 @@ histogram::get_seastar_metrics_histogram() const {
     auto &bucket = sshist.buckets[bucket_idx];
     bucket.count = iter.cumulative_count;
     bucket.upper_bound = iter.value_iterated_to;
-    iter.value_iterated_to *= (int64_t)log->log_base;
+    iter.value_iterated_to *= static_cast<int64_t>(log->log_base);
   }
 
   return sshist;

--- a/src/core/histogram.cc
+++ b/src/core/histogram.cc
@@ -105,7 +105,7 @@ histogram::print(FILE *fp) const {
 }
 
 seastar::metrics::histogram
-histogram::get_seastar_metrics_histogram() const {
+histogram::seastar_histogram_logform() const {
   // logarithmic histogram configuration. this will range from 10 microseconds
   // through around 6000 seconds with 26 buckets doubling.
   //

--- a/src/core/rpc_server.cc
+++ b/src/core/rpc_server.cc
@@ -58,7 +58,7 @@ rpc_server::rpc_server(rpc_server_args args)
       sm::make_histogram(
         "handler_dispatch_latency",
         sm::description("Server handler dispatch latency"),
-        [this] { return hist_->get_seastar_metrics_histogram(); }),
+        [this] { return hist_->seastar_histogram_logform(); }),
     });
 }
 

--- a/src/core/rpc_server.cc
+++ b/src/core/rpc_server.cc
@@ -55,6 +55,10 @@ rpc_server::rpc_server(rpc_server_args args)
         "too_large_requests", stats_->too_large_requests,
         sm::description(
           "Requests made to this server larger than max allowedd (2GB)")),
+      sm::make_histogram(
+        "handler_dispatch_latency",
+        sm::description("Server handler dispatch latency"),
+        [this] { return hist_->get_seastar_metrics_histogram(); }),
     });
 }
 

--- a/src/include/smf/histogram.h
+++ b/src/include/smf/histogram.h
@@ -7,6 +7,7 @@
 #include <utility>
 
 #include <hdr_histogram.h>
+#include <seastar/core/metrics_types.hh>
 #include <seastar/core/shared_ptr.hh>
 
 #include "smf/macros.h"
@@ -41,6 +42,8 @@ struct hist_t {
     }
   }
   hdr_histogram *hist = nullptr;
+  uint64_t sample_count = 0;
+  uint64_t sample_sum = 0;
 };
 
 /// brief - simple wrapper for hdr_histogram_c project
@@ -75,6 +78,8 @@ class histogram final : public seastar::enable_lw_shared_from_this<histogram> {
   std::unique_ptr<histogram_measure> auto_measure();
 
   int print(FILE *fp) const;
+
+  seastar::metrics::histogram get_seastar_metrics_histogram() const;
 
   ~histogram();
 

--- a/src/include/smf/histogram.h
+++ b/src/include/smf/histogram.h
@@ -79,7 +79,7 @@ class histogram final : public seastar::enable_lw_shared_from_this<histogram> {
 
   int print(FILE *fp) const;
 
-  seastar::metrics::histogram get_seastar_metrics_histogram() const;
+  seastar::metrics::histogram seastar_histogram_logform() const;
 
   ~histogram();
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -15,3 +15,10 @@ smf_test(
   SOURCE_DIRECTORY ${TOOR}
   LIBRARIES smf GTest::gtest
   )
+
+add_executable(smf_histgen histgen.cc)
+target_link_libraries(smf_histgen smf)
+target_include_directories(smf_histgen
+  PUBLIC ${CMAKE_CURRENT_BINARY_DIR}
+  PUBLIC ${PROJECT_SOURCE_DIR}/src/include
+)

--- a/src/tests/histgen.cc
+++ b/src/tests/histgen.cc
@@ -39,7 +39,7 @@ class histgen_server {
   ~histgen_server() {}
 
   seastar::future<>
-  start() {
+  serve() {
     std::random_device rd;
     std::mt19937 gen(rd());
     std::uniform_int_distribution<uint64_t> dist(args.min_val, args.max_val);
@@ -109,6 +109,6 @@ main(int args, char **argv, char **env) {
     args.num_samples = cfg["num_samples"].as<uint32_t>();
 
     return server.start(args).then(
-      [&server] { return server.invoke_on_all(&histgen_server::start); });
+      [&server] { return server.invoke_on_all(&histgen_server::serve); });
   });
 }

--- a/src/tests/histgen.cc
+++ b/src/tests/histgen.cc
@@ -1,0 +1,114 @@
+// Copyright 2019 SMF Authors
+//
+
+#include <chrono>
+#include <iostream>
+#include <random>
+
+#include <seastar/core/app-template.hh>
+#include <seastar/core/distributed.hh>
+#include <seastar/core/metrics_registration.hh>
+#include <seastar/core/prometheus.hh>
+#include <seastar/http/httpd.hh>
+
+#include "smf/histogram.h"
+
+struct histgen_server_args {
+  seastar::sstring ip = "";
+  uint16_t port = 33140;
+  uint64_t min_val;
+  uint64_t max_val;
+  uint32_t num_samples;
+};
+
+class histgen_server {
+ public:
+  histgen_server(histgen_server_args args)
+    : args(args), hist(smf::histogram::make_lw_shared()),
+      http_server("histgen server") {
+    namespace sm = seastar::metrics;
+    metrics.add_group(
+      "histgen_server",
+      {
+        sm::make_histogram(
+          "synthetic_histogram", sm::description("Synthetic histogram data"),
+          [this] { return hist->get_seastar_metrics_histogram(); }),
+      });
+  }
+
+  ~histgen_server() {}
+
+  seastar::future<>
+  start() {
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_int_distribution<uint64_t> dist(args.min_val, args.max_val);
+    boost::counting_iterator<int> from(0);
+    boost::counting_iterator<int> to(args.num_samples);
+    return seastar::do_for_each(from, to,
+                                [&](int i) mutable {
+                                  hist->record(dist(gen));
+                                  return seastar::make_ready_future<>();
+                                })
+      .then([&] {
+        seastar::prometheus::config conf;
+        conf.metric_help = "synthetic histogram";
+        conf.prefix = "histgen";
+        return seastar::prometheus::add_prometheus_routes(http_server, conf)
+          .then([&] {
+            return http_server.listen(seastar::make_ipv4_address(
+              args.ip.empty() ? seastar::ipv4_addr{args.port}
+                              : seastar::ipv4_addr{args.ip, args.port}));
+          });
+      });
+  }
+
+  seastar::future<>
+  stop() {
+    return http_server.stop();
+  }
+
+  histgen_server_args args;
+  seastar::lw_shared_ptr<smf::histogram> hist;
+  seastar::http_server http_server;
+  seastar::metrics::metric_groups metrics;
+};
+
+void
+cli_opts(boost::program_options::options_description_easy_init o) {
+  namespace po = boost::program_options;
+  o("ip", po::value<std::string>()->default_value("127.0.0.1"),
+    "ip to connect to");
+  o("port", po::value<uint16_t>()->default_value(20777),
+    "port for http stats service");
+  o("min_val", po::value<uint64_t>()->default_value(0), "minimum sample value");
+  o("max_val",
+    po::value<uint64_t>()->default_value(smf::kDefaultHistogramMaxValue),
+    "maximum sample value");
+  o("num_samples", po::value<uint32_t>()->default_value(10000),
+    "number of sample values");
+}
+
+int
+main(int args, char **argv, char **env) {
+  seastar::sharded<histgen_server> server;
+
+  seastar::app_template app;
+  cli_opts(app.add_options());
+
+  return app.run_deprecated(args, argv, [&] {
+    seastar::engine().at_exit([&] { return server.stop(); });
+
+    auto &cfg = app.configuration();
+
+    histgen_server_args args;
+    args.ip = cfg["ip"].as<std::string>();
+    args.port = cfg["port"].as<uint16_t>();
+    args.min_val = cfg["min_val"].as<uint64_t>();
+    args.max_val = cfg["max_val"].as<uint64_t>();
+    args.num_samples = cfg["num_samples"].as<uint32_t>();
+
+    return server.start(args).then(
+      [&server] { return server.invoke_on_all(&histgen_server::start); });
+  });
+}

--- a/src/tests/histgen.cc
+++ b/src/tests/histgen.cc
@@ -32,7 +32,7 @@ class histgen_server {
       {
         sm::make_histogram(
           "synthetic_histogram", sm::description("Synthetic histogram data"),
-          [this] { return hist->get_seastar_metrics_histogram(); }),
+          [this] { return hist->seastar_histogram_logform(); }),
       });
   }
 


### PR DESCRIPTION
The HDR histogram doesn't map cleanly to the seastar histogram type. Well, I haven't dug into it deeply enough to be certain. But that mapping needs some attention. It may make sense to use the percentiles strategy to calculate boundaries then actually use the linear histogram iteration to create buckets.