### PR TITLE
Feature/upgrade seastar api v6

### DIFF
--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -83,7 +83,7 @@ ExternalProject_Add(protobuf
 set(dpdk_quadruple ${CMAKE_SYSTEM_PROCESSOR}-native-linuxapp-gcc)
 
 set (dpdk_args
-  "EXTRA_CFLAGS=-Wno-error -fcommon"
+  EXTRA_CFLAGS=-Wno-error
   O=<BINARY_DIR>
   DESTDIR=@SMF_DEPS_INSTALL_DIR@
   T=${dpdk_quadruple})
@@ -278,14 +278,10 @@ ExternalProject_Add(seastar
   GIT_REPOSITORY https://github.com/vectorizedio/seastar.git
   GIT_TAG d80beb8f0e5f926b79db9538e62c32c5d3bcc076
   INSTALL_DIR    @SMF_DEPS_INSTALL_DIR@
-  CMAKE_COMMAND ${CMAKE_COMMAND} -E env ${cmake_build_env} ${CMAKE_COMMAND}
   CMAKE_ARGS
     -DCMAKE_BUILD_TYPE=@CMAKE_BUILD_TYPE@
     -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
     -DCMAKE_PREFIX_PATH=<INSTALL_DIR>
-    -DBoost_USE_STATIC_LIBS=OFF
-    -DBoost_NO_BOOST_CMAKE=ON
-    -DBoost_NO_SYSTEM_PATHS=TRUE
     -DSeastar_INSTALL=ON
     -DSeastar_DPDK=OFF
     -DSeastar_APPS=OFF
@@ -294,10 +290,10 @@ ExternalProject_Add(seastar
     -DSeastar_TESTING=OFF
     -DSeastar_CXX_FLAGS=-Wno-error
     -DSeastar_LD_FLAGS=-pthread
+    -DSeastar_STD_OPTIONAL_VARIANT_STRINGVIEW=ON
     -DSeastar_API_LEVEL=6
     -DSeastar_CXX_DIALECT=c++17
     -DSeastar_UNUSED_RESULT_ERROR=ON
-    -DSeastar_STD_OPTIONAL_VARIANT_STRINGVIEW=ON
   DEPENDS
     fmt
     boost

--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -83,7 +83,7 @@ ExternalProject_Add(protobuf
 set(dpdk_quadruple ${CMAKE_SYSTEM_PROCESSOR}-native-linuxapp-gcc)
 
 set (dpdk_args
-  EXTRA_CFLAGS=-Wno-error
+  "EXTRA_CFLAGS=-Wno-error -fcommon"
   O=<BINARY_DIR>
   DESTDIR=@SMF_DEPS_INSTALL_DIR@
   T=${dpdk_quadruple})
@@ -212,8 +212,8 @@ ExternalProject_Add(libpciaccess
   INSTALL_COMMAND ${make_command} install)
 
 ExternalProject_Add(hwloc
-  URL https://download.open-mpi.org/release/hwloc/v1.11/hwloc-1.11.5.tar.gz
-  URL_MD5 8f5fe6a9be2eb478409ad5e640b2d3ba
+  URL https://download.open-mpi.org/release/hwloc/v2.2/hwloc-2.2.0.tar.gz
+  URL_MD5 762c93cdca3249eed4627c4a160192bd
   INSTALL_DIR @SMF_DEPS_INSTALL_DIR@
   CONFIGURE_COMMAND
     <SOURCE_DIR>/configure
@@ -275,13 +275,17 @@ ExternalProject_Add(lksctp-tools
   INSTALL_COMMAND ${make_command} install)
 
 ExternalProject_Add(seastar
-  URL https://github.com/vectorizedio/seastar/archive/319d359.tar.gz
-  URL_MD5 341f15559319f93463961db03978d45c
+  GIT_REPOSITORY https://github.com/vectorizedio/seastar.git
+  GIT_TAG d80beb8f0e5f926b79db9538e62c32c5d3bcc076
   INSTALL_DIR    @SMF_DEPS_INSTALL_DIR@
+  CMAKE_COMMAND ${CMAKE_COMMAND} -E env ${cmake_build_env} ${CMAKE_COMMAND}
   CMAKE_ARGS
     -DCMAKE_BUILD_TYPE=@CMAKE_BUILD_TYPE@
     -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
     -DCMAKE_PREFIX_PATH=<INSTALL_DIR>
+    -DBoost_USE_STATIC_LIBS=OFF
+    -DBoost_NO_BOOST_CMAKE=ON
+    -DBoost_NO_SYSTEM_PATHS=TRUE
     -DSeastar_INSTALL=ON
     -DSeastar_DPDK=OFF
     -DSeastar_APPS=OFF
@@ -290,9 +294,10 @@ ExternalProject_Add(seastar
     -DSeastar_TESTING=OFF
     -DSeastar_CXX_FLAGS=-Wno-error
     -DSeastar_LD_FLAGS=-pthread
-    -DSeastar_STD_OPTIONAL_VARIANT_STRINGVIEW=ON
+    -DSeastar_API_LEVEL=1
     -DSeastar_CXX_DIALECT=c++17
     -DSeastar_UNUSED_RESULT_ERROR=ON
+    -DSeastar_STD_OPTIONAL_VARIANT_STRINGVIEW=ON
   DEPENDS
     fmt
     boost

--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -294,7 +294,7 @@ ExternalProject_Add(seastar
     -DSeastar_TESTING=OFF
     -DSeastar_CXX_FLAGS=-Wno-error
     -DSeastar_LD_FLAGS=-pthread
-    -DSeastar_API_LEVEL=1
+    -DSeastar_API_LEVEL=2
     -DSeastar_CXX_DIALECT=c++17
     -DSeastar_UNUSED_RESULT_ERROR=ON
     -DSeastar_STD_OPTIONAL_VARIANT_STRINGVIEW=ON

--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -294,7 +294,7 @@ ExternalProject_Add(seastar
     -DSeastar_TESTING=OFF
     -DSeastar_CXX_FLAGS=-Wno-error
     -DSeastar_LD_FLAGS=-pthread
-    -DSeastar_API_LEVEL=2
+    -DSeastar_API_LEVEL=3
     -DSeastar_CXX_DIALECT=c++17
     -DSeastar_UNUSED_RESULT_ERROR=ON
     -DSeastar_STD_OPTIONAL_VARIANT_STRINGVIEW=ON

--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -294,7 +294,7 @@ ExternalProject_Add(seastar
     -DSeastar_TESTING=OFF
     -DSeastar_CXX_FLAGS=-Wno-error
     -DSeastar_LD_FLAGS=-pthread
-    -DSeastar_API_LEVEL=3
+    -DSeastar_API_LEVEL=6
     -DSeastar_CXX_DIALECT=c++17
     -DSeastar_UNUSED_RESULT_ERROR=ON
     -DSeastar_STD_OPTIONAL_VARIANT_STRINGVIEW=ON

--- a/demo_apps/cpp/client/main.cc
+++ b/demo_apps/cpp/client/main.cc
@@ -6,6 +6,7 @@
 
 #include <seastar/core/app-template.hh>
 #include <seastar/core/distributed.hh>
+#include <seastar/core/reactor.hh>
 
 #include "smf/histogram_seastar_utils.h"
 #include "smf/load_channel.h"

--- a/demo_apps/cpp/server/main.cc
+++ b/demo_apps/cpp/server/main.cc
@@ -6,6 +6,7 @@
 
 #include <seastar/core/app-template.hh>
 #include <seastar/core/distributed.hh>
+#include <seastar/core/reactor.hh>
 #include <seastar/net/api.hh>
 
 #include "smf/histogram_seastar_utils.h"

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -66,6 +66,7 @@ function debs() {
         pkg-config \
         xfslibs-dev \
         systemtap-sdt-dev \
+        valgrind \
         ragel ${extra}
 }
 
@@ -116,6 +117,7 @@ function rpms() {
         libasan \
         libubsan \
         libatomic \
+        valgrind-devel \
         doxygen ${extra}
 
     if [ -n "$dts_ver" ]; then

--- a/src/core/histogram_seastar_utils.cc
+++ b/src/core/histogram_seastar_utils.cc
@@ -6,6 +6,7 @@
 
 #include <seastar/core/file.hh>
 #include <seastar/core/reactor.hh>
+#include <seastar/core/fstream.hh>
 // smf
 #include "smf/histogram.h"
 #include "smf/log.h"

--- a/src/core/histogram_seastar_utils.cc
+++ b/src/core/histogram_seastar_utils.cc
@@ -39,14 +39,14 @@ histogram_seastar_utils::write_histogram(seastar::sstring filename,
     seastar::open_file_dma(filename, flags),
     [h = std::move(h)](seastar::file file) mutable {
       return  seastar::make_file_output_stream(std::move(file))
-        .then([h = std::move(h)](seastar::output_stream<char> f) mutable {
+        .then([h = std::move(h)](seastar::output_stream<char> out) mutable {
           return histogram_seastar_utils::print_histogram(h)
-            .then([f = std::move(f)](seastar::temporary_buffer<char> buf) mutable {
-              return f.write(buf.get(), buf.size())
-                .then([f = std::move(f)]() mutable {
-                  return f.flush()
-                    .then([f = std::move(f)]() mutable { 
-                      return f.close().finally([f = std::move(f)] {}); 
+            .then([out = std::move(out)](seastar::temporary_buffer<char> buf) mutable {
+              return out.write(buf.get(), buf.size())
+                .then([out = std::move(out)]() mutable {
+                  return out.flush()
+                    .then([out = std::move(out)]() mutable { 
+                      return out.close().finally([out = std::move(out)] {}); 
                     });
                 });
             });

--- a/src/core/histogram_seastar_utils.cc
+++ b/src/core/histogram_seastar_utils.cc
@@ -32,24 +32,18 @@ histogram_seastar_utils::print_histogram(histogram *h) {
 seastar::future<>
 histogram_seastar_utils::write_histogram(seastar::sstring filename,
                                          histogram *h) {
-  static constexpr const size_t buf_size = 4096;
   auto flags = seastar::open_flags::rw | seastar::open_flags::create
                  | seastar::open_flags::truncate;
 
   return seastar::with_file_close_on_failure(
-
     seastar::open_file_dma(filename, flags),
     [h = std::move(h)](seastar::file file) mutable {
-
-      return  seastar::make_file_output_stream(std::move(file), buf_size)
+      return  seastar::make_file_output_stream(std::move(file))
         .then([h = std::move(h)](seastar::output_stream<char> f) mutable {
-
           return histogram_seastar_utils::print_histogram(h)
             .then([f = std::move(f)](seastar::temporary_buffer<char> buf) mutable {
-
               return f.write(buf.get(), buf.size())
                 .then([f = std::move(f)]() mutable {
-
                   return f.flush()
                     .then([f = std::move(f)]() mutable { 
                       return f.close().finally([f = std::move(f)] {}); 

--- a/src/core/rpc_recv_context.cc
+++ b/src/core/rpc_recv_context.cc
@@ -3,6 +3,7 @@
 #include "smf/rpc_recv_context.h"
 
 #include <chrono>
+#include <optional>
 
 #include <seastar/core/timer.hh>
 // seastar BUG: when compiling w/ -O3
@@ -43,43 +44,43 @@ max_flatbuffers_size() {
   return static_cast<uint32_t>(FLATBUFFERS_MAX_BUFFER_SIZE);
 }
 
-seastar::future<smf::compat::optional<rpc_recv_context>>
+seastar::future<std::optional<rpc_recv_context>>
 rpc_recv_context::parse_payload(rpc_connection *conn, rpc::header hdr) {
-  using ret_type = smf::compat::optional<rpc_recv_context>;
+  using ret_type = std::optional<rpc_recv_context>;
   return conn->istream.read_exactly(hdr.size())
     .then([conn, hdr](seastar::temporary_buffer<char> body) mutable {
       if (hdr.size() != body.size()) {
         LOG_ERROR("Read incorrect number of bytes `{}`, expected header: `{}`",
                   body.size(), hdr);
-        return seastar::make_ready_future<ret_type>(smf::compat::nullopt);
+        return seastar::make_ready_future<ret_type>(std::nullopt);
       }
       if (hdr.size() > max_flatbuffers_size()) {
         LOG_ERROR("Bad payload. Body is >  FLATBUFFERS_MAX_BUFFER_SIZE");
-        return seastar::make_ready_future<ret_type>(smf::compat::nullopt);
+        return seastar::make_ready_future<ret_type>(std::nullopt);
       }
       if (hdr.bitflags() &
           rpc::header_bit_flags::header_bit_flags_has_payload_headers) {
         LOG_ERROR("Reading payload headers is not yet implemented");
-        return seastar::make_ready_future<ret_type>(smf::compat::nullopt);
+        return seastar::make_ready_future<ret_type>(std::nullopt);
       }
 
       const uint32_t xx = rpc_checksum_payload(body.get(), body.size());
       if (xx != hdr.checksum()) {
         LOG_ERROR("Payload checksum `{}` does not match header checksum `{}`",
                   xx, hdr.checksum());
-        return seastar::make_ready_future<ret_type>(smf::compat::nullopt);
+        return seastar::make_ready_future<ret_type>(std::nullopt);
       }
 
       rpc_recv_context ctx(conn->limits, conn->remote_address, hdr,
                            std::move(body));
       return seastar::make_ready_future<ret_type>(
-        smf::compat::optional<rpc_recv_context>(std::move(ctx)));
+        std::optional<rpc_recv_context>(std::move(ctx)));
     });
 }
 
-seastar::future<smf::compat::optional<rpc::header>>
+seastar::future<std::optional<rpc::header>>
 rpc_recv_context::parse_header(rpc_connection *conn) {
-  using ret_type = smf::compat::optional<rpc::header>;
+  using ret_type = std::optional<rpc::header>;
 
   static constexpr size_t kRPCHeaderSize = sizeof(rpc::header);
   DLOG_THROW_IF(
@@ -93,25 +94,25 @@ rpc_recv_context::parse_header(rpc_connection *conn) {
         LOG_ERROR_IF(conn->is_valid(),
                      "Invalid header size `{}`, expected `{}`, skipping req",
                      header.size(), kRPCHeaderSize);
-        return seastar::make_ready_future<ret_type>(smf::compat::nullopt);
+        return seastar::make_ready_future<ret_type>(std::nullopt);
       }
       auto hdr = rpc::header();
       std::memcpy(&hdr, header.get(), kRPCHeaderSize);
       if (hdr.size() == 0) {
         LOG_ERROR("Emty body to parse. skipping");
-        return seastar::make_ready_future<ret_type>(smf::compat::nullopt);
+        return seastar::make_ready_future<ret_type>(std::nullopt);
       }
       if (hdr.compression() > rpc::compression_flags_MAX) {
         LOG_ERROR("Compression out of range", hdr);
-        return seastar::make_ready_future<ret_type>(smf::compat::nullopt);
+        return seastar::make_ready_future<ret_type>(std::nullopt);
       }
       if (hdr.checksum() <= 0) {
         LOG_ERROR("checksum is empty");
-        return seastar::make_ready_future<ret_type>(smf::compat::nullopt);
+        return seastar::make_ready_future<ret_type>(std::nullopt);
       }
       if (hdr.meta() <= 0) {
         LOG_ERROR("meta is empty");
-        return seastar::make_ready_future<ret_type>(smf::compat::nullopt);
+        return seastar::make_ready_future<ret_type>(std::nullopt);
       }
       if (hdr.compression() ==
           rpc::compression_flags::compression_flags_disabled) {

--- a/src/include/smf/rpc_client.h
+++ b/src/include/smf/rpc_client.h
@@ -5,6 +5,7 @@
 #include <memory>
 #include <utility>
 #include <vector>
+#include <optional>
 
 #include <seastar/core/gate.hh>
 #include <seastar/core/shared_ptr.hh>
@@ -15,7 +16,6 @@
 #include "smf/rpc_envelope.h"
 #include "smf/rpc_filter.h"
 #include "smf/rpc_recv_typed_context.h"
-#include "smf/std-compat.h"
 
 namespace smf {
 
@@ -60,7 +60,7 @@ struct rpc_client_opts {
 class rpc_client {
  public:
   struct work_item {
-    using promise_t = seastar::promise<smf::compat::optional<rpc_recv_context>>;
+    using promise_t = seastar::promise<std::optional<rpc_recv_context>>;
     explicit work_item(uint16_t idx) : session(idx) {}
     ~work_item() {}
 
@@ -152,7 +152,7 @@ class rpc_client {
   seastar::future<rpc_envelope> apply_outgoing_filters(rpc_envelope);
 
  private:
-  seastar::future<smf::compat::optional<rpc_recv_context>> raw_send(rpc_envelope e);
+  seastar::future<std::optional<rpc_recv_context>> raw_send(rpc_envelope e);
   seastar::future<> do_reads();
   seastar::future<> dispatch_write(rpc_envelope e);
   seastar::future<> process_one_request();

--- a/src/include/smf/rpc_connection.h
+++ b/src/include/smf/rpc_connection.h
@@ -2,12 +2,12 @@
 //
 #pragma once
 #include <utility>
+#include <optional>
 // seastar
 #include <seastar/core/iostream.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/net/api.hh>
 
-#include "smf/std-compat.h"
 #include "smf/macros.h"
 #include "smf/rpc_connection_limits.h"
 
@@ -74,7 +74,7 @@ class rpc_connection final {
   SMF_DISALLOW_COPY_AND_ASSIGN(rpc_connection);
 
  private:
-  smf::compat::optional<seastar::sstring> error_;
+  std::optional<seastar::sstring> error_;
   bool enabled_{true};
 };
 }  // namespace smf

--- a/src/include/smf/rpc_recv_context.h
+++ b/src/include/smf/rpc_recv_context.h
@@ -2,6 +2,7 @@
 //
 #pragma once
 // std
+#include <optional>
 // seastar
 #include <seastar/core/iostream.hh>
 #include <seastar/net/api.hh>
@@ -10,7 +11,6 @@
 #include "smf/rpc_connection.h"
 #include "smf/rpc_connection_limits.h"
 #include "smf/rpc_generated.h"
-#include "smf/std-compat.h"
 
 namespace smf {
 struct rpc_recv_context {
@@ -22,9 +22,9 @@ struct rpc_recv_context {
   /// size of the header, so we parse sizeof(Header). We with this information
   /// we parse the body of the request
   ///
-  static seastar::future<smf::compat::optional<rpc::header>>
+  static seastar::future<std::optional<rpc::header>>
   parse_header(rpc_connection *conn);
-  static seastar::future<smf::compat::optional<rpc_recv_context>>
+  static seastar::future<std::optional<rpc_recv_context>>
   parse_payload(rpc_connection *conn, rpc::header hdr);
 
   explicit rpc_recv_context(

--- a/src/include/smf/rpc_recv_typed_context.h
+++ b/src/include/smf/rpc_recv_typed_context.h
@@ -4,6 +4,7 @@
 
 #include "smf/macros.h"
 #include "smf/rpc_recv_context.h"
+#include <optional>
 
 namespace smf {
 
@@ -14,9 +15,9 @@ class rpc_recv_typed_context {
 
  public:
   using type = T;
-  using opt_recv_ctx_t = smf::compat::optional<rpc_recv_context>;
+  using opt_recv_ctx_t = std::optional<rpc_recv_context>;
 
-  rpc_recv_typed_context() : ctx(smf::compat::nullopt) {}
+  rpc_recv_typed_context() : ctx(std::nullopt) {}
 
   explicit rpc_recv_typed_context(opt_recv_ctx_t t) : ctx(std::move(t)) {
     if (SMF_LIKELY(!!ctx)) {

--- a/src/include/smf/rpc_server.h
+++ b/src/include/smf/rpc_server.h
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <type_traits>
 #include <unordered_map>
+#include <optional>
 
 #include <seastar/core/distributed.hh>
 #include <seastar/core/gate.hh>
@@ -81,7 +82,7 @@ class rpc_server {
   seastar::future<>
   dispatch_rpc(int32_t payload_size,
                seastar::lw_shared_ptr<rpc_server_connection> conn,
-               smf::compat::optional<rpc_recv_context> ctx);
+               std::optional<rpc_recv_context> ctx);
 
   /// \brief main difference between dispatch_rpc and do_dispatch_rpc
   /// is that the former just wraps the calls in a safe seastar::gate

--- a/src/include/smf/rpc_server_connection.h
+++ b/src/include/smf/rpc_server_connection.h
@@ -9,7 +9,6 @@
 #include "smf/log.h"
 #include "smf/rpc_connection.h"
 #include "smf/rpc_server_stats.h"
-#include "smf/std-compat.h"
 namespace smf {
 struct rpc_server_connection_options {
   explicit rpc_server_connection_options(bool _nodelay = false,

--- a/src/include/smf/std-compat.h
+++ b/src/include/smf/std-compat.h
@@ -1,9 +1,0 @@
-// Copyright 2018 Alexander Gallego
-//
-#pragma once
-
-#include <seastar/util/std-compat.hh>
-
-namespace smf {
-namespace compat = seastar::compat;
-}  // namespace smf

--- a/src/integration_tests/rpc/main.cc
+++ b/src/integration_tests/rpc/main.cc
@@ -6,6 +6,7 @@
 // seastar
 #include <seastar/core/app-template.hh>
 #include <seastar/core/distributed.hh>
+#include <seastar/core/reactor.hh>
 // smf
 #include "integration_tests/demo_service.smf.fb.h"
 #include "integration_tests/non_root_port.h"

--- a/src/integration_tests/rpc_backpressure/main.cc
+++ b/src/integration_tests/rpc_backpressure/main.cc
@@ -6,6 +6,7 @@
 // seastar
 #include <seastar/core/app-template.hh>
 #include <seastar/core/distributed.hh>
+#include <seastar/core/reactor.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/net/api.hh>

--- a/src/integration_tests/rpc_multiple_remote_addrs/main.cc
+++ b/src/integration_tests/rpc_multiple_remote_addrs/main.cc
@@ -10,6 +10,7 @@
 // seastar
 #include <seastar/core/app-template.hh>
 #include <seastar/core/distributed.hh>
+#include <seastar/core/reactor.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/net/api.hh>

--- a/src/integration_tests/rpc_reconnect_with_timeout/main.cc
+++ b/src/integration_tests/rpc_reconnect_with_timeout/main.cc
@@ -6,6 +6,7 @@
 // seastar
 #include <seastar/core/app-template.hh>
 #include <seastar/core/distributed.hh>
+#include <seastar/core/reactor.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/net/api.hh>

--- a/src/integration_tests/rpc_recv_timeout/main.cc
+++ b/src/integration_tests/rpc_recv_timeout/main.cc
@@ -7,6 +7,7 @@
 #include <seastar/core/app-template.hh>
 #include <seastar/core/distributed.hh>
 #include <seastar/core/sleep.hh>
+#include <seastar/core/reactor.hh>
 #include <seastar/net/api.hh>
 // smf
 #include "integration_tests/non_root_port.h"

--- a/src/integration_tests/rpc_send_timeout/main.cc
+++ b/src/integration_tests/rpc_send_timeout/main.cc
@@ -6,6 +6,7 @@
 // seastar
 #include <seastar/core/app-template.hh>
 #include <seastar/core/distributed.hh>
+#include <seastar/core/reactor.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/net/api.hh>

--- a/src/smfc/codegen.cc
+++ b/src/smfc/codegen.cc
@@ -41,13 +41,13 @@ codegen::service_count() const {
   return parser_->services_.vec.size();
 }
 
-smf::compat::optional<std::string>
+std::optional<std::string>
 codegen::parse() {
   if (parsed_) {
     if (!parser_->error_.empty()) {
       return "Parser in error state: " + parser_->error_;
     }
-    return smf::compat::nullopt;
+    return std::nullopt;
   }
   parsed_ = true;
 
@@ -71,10 +71,10 @@ codegen::parse() {
     return "Could not PARSE file: " + parser_->error_;
   }
 
-  return smf::compat::nullopt;
+  return std::nullopt;
 }
 
-smf::compat::optional<std::string>
+std::optional<std::string>
 codegen::gen() {
   auto x = parse();
   if (x) { return x; }
@@ -111,7 +111,7 @@ codegen::gen() {
       LOG(ERROR) << "Uknown code generator";
     }
   }
-  return smf::compat::nullopt;
+  return std::nullopt;
 }
 
 }  // namespace smf_gen

--- a/src/smfc/codegen.h
+++ b/src/smfc/codegen.h
@@ -5,18 +5,18 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <optional>
 
 #include <flatbuffers/flatbuffers.h>
 #include <flatbuffers/idl.h>
 
-#include "smf/std-compat.h"
 #include "language.h"
 
 namespace smf_gen {
 
 class codegen {
  public:
-  using status = smf::compat::optional<std::string>;
+  using status = std::optional<std::string>;
 
   codegen(std::string ifname, std::string output_dir,
           std::vector<std::string> include_dirs, std::vector<language> langs);

--- a/src/smfc/cpp_generator.cc
+++ b/src/smfc/cpp_generator.cc
@@ -443,7 +443,7 @@ cpp_generator::generate_header_prologue_includes() {
   std::map<std::string, std::string> vars;
   static const std::vector<std::string> headers = {
         "ostream", "seastar/core/sstring.hh",  
-        "smf/std-compat.h", "smf/rpc_service.h",
+        "smf/rpc_service.h",
         "smf/rpc_client.h", "smf/rpc_recv_typed_context.h",
         "smf/rpc_typed_envelope.h", "smf/log.h" };
 

--- a/src/smfc/cpp_generator.h
+++ b/src/smfc/cpp_generator.h
@@ -11,7 +11,6 @@
 #include <glog/logging.h>
 
 #include "generator.h"
-#include "smf/std-compat.h"
 
 namespace smf_gen {
 
@@ -27,7 +26,7 @@ class cpp_generator : public generator {
     return output_dir + "/" + input_filename_without_ext() + ".smf.fb.h";
   }
 
-  virtual smf::compat::optional<std::string>
+  virtual std::optional<std::string>
   gen() final {
     generate_header_prologue();
     generate_header_prologue_includes();

--- a/src/smfc/generator.h
+++ b/src/smfc/generator.h
@@ -6,13 +6,13 @@
 #include <memory>
 #include <set>
 #include <string>
+#include <optional>
 
 #include <boost/filesystem.hpp>
 #include <flatbuffers/flatbuffers.h>
 
 #include "smf_printer.h"
 #include "smf_service.h"
-#include "smf/std-compat.h"
 
 namespace smf_gen {
 class generator {
@@ -33,7 +33,7 @@ class generator {
   virtual ~generator() = default;
 
   virtual std::string output_filename() = 0;
-  virtual smf::compat::optional<std::string> gen() = 0;
+  virtual std::optional<std::string> gen() = 0;
 
   virtual const std::string &
   contents() final {
@@ -82,7 +82,7 @@ class generator {
     return flatbuffers::StripExtension(input_filename_without_path());
   }
 
-  virtual smf::compat::optional<std::string>
+  virtual std::optional<std::string>
   save_conents_to_file() {
     auto outname = output_filename();
     if (boost::filesystem::exists(outname)) {
@@ -91,7 +91,7 @@ class generator {
     if (!flatbuffers::SaveFile(outname.c_str(), printer_.contents(), false)) {
       return "Could not create filename: " + outname;
     }
-    return smf::compat::nullopt;
+    return std::nullopt;
   }
 
  protected:

--- a/src/smfc/go_generator.h
+++ b/src/smfc/go_generator.h
@@ -9,7 +9,6 @@
 #include <boost/filesystem.hpp>
 
 #include "generator.h"
-#include "smf/std-compat.h"
 
 namespace smf_gen {
 
@@ -35,7 +34,7 @@ class go_generator : public generator {
     return str.str();
   }
 
-  virtual smf::compat::optional<std::string>
+  virtual std::optional<std::string>
   gen() final {
     generate_header_prologue();
     generate_header_includes();

--- a/src/smfc/main.cc
+++ b/src/smfc/main.cc
@@ -12,7 +12,6 @@
 #include <glog/logging.h>
 
 #include "codegen.h"
-#include "smf/std-compat.h"
 
 DEFINE_string(filename, "", "filename to parse");
 DEFINE_string(include_dirs, "", "extra include directories");

--- a/src/smfc/python_generator.h
+++ b/src/smfc/python_generator.h
@@ -8,7 +8,6 @@
 #include <boost/filesystem.hpp>
 
 #include "generator.h"
-#include "smf/std-compat.h"
 
 namespace smf_gen {
 
@@ -32,7 +31,7 @@ class python_generator final : public generator {
     return str.str();
   }
 
-  virtual smf::compat::optional<std::string>
+  virtual std::optional<std::string>
   gen() final {
     generate_header_prologue();
     generate_header_includes();

--- a/src/tests/histgen.cc
+++ b/src/tests/histgen.cc
@@ -9,6 +9,7 @@
 #include <seastar/core/distributed.hh>
 #include <seastar/core/metrics_registration.hh>
 #include <seastar/core/prometheus.hh>
+#include <seastar/core/reactor.hh>
 #include <seastar/http/httpd.hh>
 
 #include "smf/histogram.h"


### PR DESCRIPTION
closes #374 

# Big changes
* **upgrade to seastar v6**: aligned cmake dependency to redpanda version git hash d80beb8f0e5f926b79db9538e62c32c5d3bcc076  
* **upgrade hwloc**: aligned to redpanda version v2.2
* **removed std-compat.h**
*  **refactor make_file_output_stream**: function now returns a future

# Minor changes
* **add valgrind to deps** required by seastar v6
* **other minor header fixes**
