### PR TITLE
smfc: fix redefinition of 'operator<<'

### DIFF
--- a/src/smfc/cpp_generator.cc
+++ b/src/smfc/cpp_generator.cc
@@ -405,9 +405,7 @@ cpp_generator::generate_header_prologue() {
 void
 cpp_generator::generate_header_prologue_forward_decl_external() {
   for (auto &srv : services()) {
-    for (auto &srv : services()) {
-      print_std_ostream_services(printer_, srv.get());
-    }
+    print_std_ostream_services(printer_, srv.get());
   }
   printer_.print("\n");
 }
@@ -442,7 +440,7 @@ cpp_generator::generate_header_prologue_includes() {
   VLOG(1) << "get_header_includes";
   std::map<std::string, std::string> vars;
   static const std::vector<std::string> headers = {
-        "ostream", "seastar/core/sstring.hh",  
+        "ostream", "seastar/core/sstring.hh",
         "smf/rpc_service.h",
         "smf/rpc_client.h", "smf/rpc_recv_typed_context.h",
         "smf/rpc_typed_envelope.h", "smf/log.h" };


### PR DESCRIPTION
Signed-off-by: youjiali1995 <zlwgx1023@gmail.com>

CPP generator will generate mulitple definitions of 'operator<<' for one service if the `fbs` contains more than one service.
