### PR TITLE
chore: quotes include for rpc_generated.h

### DIFF
--- a/src/core/rpc_envelope.cc
+++ b/src/core/rpc_envelope.cc
@@ -7,7 +7,7 @@
 #include <utility>
 
 #include <smf/log.h>
-#include <smf/rpc_generated.h>
+#include "smf/rpc_generated.h"
 
 #include "smf/rpc_header_ostream.h"
 #include "smf/rpc_header_utils.h"

--- a/src/include/smf/rpc_header_ostream.h
+++ b/src/include/smf/rpc_header_ostream.h
@@ -4,7 +4,7 @@
 #include <bitset>
 #include <iostream>
 
-#include <smf/rpc_generated.h>
+#include "smf/rpc_generated.h"
 
 namespace std {
 inline ostream &


### PR DESCRIPTION
This makes it easy to build smf using bazel with auto-generated fbs.

I probably could make it include as a system header in bazel but this seems like a valid change.